### PR TITLE
Srijit Seal's standardizer

### DIFF
--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -31,7 +31,7 @@ class StandardizeMolecule:
         num_cpu: int = 1,
         limit_rows: int = None,
         augment: bool = False,
-        method: str = "jump",
+        method: str = "jump_canonical",
         random_seed: int = 42,
     ):
         """
@@ -42,7 +42,7 @@ class StandardizeMolecule:
         :param num_cpu: Number of CPUs to use (default: 1)
         :param limit_rows: Limit the number of rows to be processed (optional)
         :param augment: The output is the input file augmented with the standardized SMILES, InChI, and InChIKey (default: False)
-        :param method: Standardization method to use: "jump" or "seal" (default: "jump")
+        :param method: Standardization method to use: "jump_canonical" or "jump_alternate_1" (default: "jump_canonical")
 
         """
         self.input = input

--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -85,7 +85,12 @@ class StandardizeMolecule:
         if mol is None:
             logging.error(f"Reading Error, {smiles}")
             return pd.DataFrame(
-                columns=["SMILES_original", "SMILES_standardized", "canonical_smiles"]
+                columns=[
+                    "SMILES_original",
+                    "SMILES_standardized",
+                    "InChI_standardized",
+                    "InChIKey_standardized",
+                ]
             )
 
         try:

--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -32,6 +32,7 @@ class StandardizeMolecule:
         limit_rows: int = None,
         augment: bool = False,
         method: str = "jump",
+        random_seed: int = 42,
     ):
         """
         Initialize the class.
@@ -50,6 +51,14 @@ class StandardizeMolecule:
         self.limit_rows = limit_rows
         self.augment = augment
         self.method = method
+        self.random_seed = random_seed
+
+        # check if method is valid
+
+        if self.method not in ["jump_canonical", "jump_alternate_1"]:
+            raise ValueError(
+                "Method must be either 'jump_canonical' or 'jump_alternate_1'."
+            )
 
     def _standardize_structure(self, smiles):
         """
@@ -65,6 +74,9 @@ class StandardizeMolecule:
 
         # Disable RDKit logging
         block = BlockLogs()
+
+        # Set the random seed for reproducibility within each task
+        np.random.seed(self.random_seed)
 
         # Read SMILES and convert it to RDKit mol object
         mol = MolFromSmiles(smiles)
@@ -151,7 +163,9 @@ class StandardizeMolecule:
                 smiles_standardized = MolToSmiles(mol_standardized)
 
             else:
-                raise ValueError("Method must be either 'jump' or 'seal'")
+                raise ValueError(
+                    "Method must be either 'jump_canonical' or 'jump_alternate_1'"
+                )
 
             # Convert the mol object to InChI
             inchi_standardized = MolToInchi(mol_standardized)

--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -85,12 +85,7 @@ class StandardizeMolecule:
         if mol is None:
             logging.error(f"Reading Error, {smiles}")
             return pd.DataFrame(
-                columns=[
-                    "SMILES_original",
-                    "SMILES_standardized",
-                    "InChI_standardized",
-                    "InChIKey_standardized",
-                ]
+                columns=["SMILES_original", "SMILES_standardized", "canonical_smiles"]
             )
 
         try:

--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -63,8 +63,8 @@ class StandardizeMolecule:
 
         smiles_original = smiles
 
-        # # Disable RDKit logging
-        # block = BlockLogs()
+        # Disable RDKit logging
+        block = BlockLogs()
 
         # Read SMILES and convert it to RDKit mol object
         mol = MolFromSmiles(smiles)

--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -254,6 +254,7 @@ class StandardizeMolecule:
                 self.input,
                 sep=sep,
                 skiprows=self.skip_rows_bang(self.input),
+                low_memory=False
             )
 
         elif isinstance(self.input, pd.DataFrame):

--- a/StandardizeMolecule.py
+++ b/StandardizeMolecule.py
@@ -86,7 +86,7 @@ class StandardizeMolecule:
             mol_dict = {}
             is_finalize = False
 
-            if self.method == "jump":
+            if self.method == "jump_canonical":
 
                 for _ in range(5):
                     # standardize molecules using MolVS and RDKit
@@ -117,7 +117,7 @@ class StandardizeMolecule:
                     # ... and the corresponding mol object
                     mol_standardized = mol_dict[smiles_standardized]
 
-            elif self.method == "seal":
+            elif self.method == "jump_alternate_1":
 
                 # This solved phosphate oxidation in most cases but introduces a problem for some compounds: eg. geldanamycin where the stable strcutre is returned
                 inchi_standardised = MolToInchi(mol)


### PR DESCRIPTION
Test with

```
python StandardizeMolecule.py \
   --input=..//JUMP-Target/master/JUMP-Target-2_compound_metadata.tsv \
   --output /tmp/JUMP-Target-2_compound_metadata.csv \
   --num_cpu=40   --augment --method=jump_alternate_1 --random_seed=42
```

```diff
diff --git a/3.standardize/standardize_ksiling_jumpmoa_jumptarget2/data/05_release/2022_10_18_JUMP-CP_compound_library.csv b/3.standardize/standardize_ksiling_jumpmoa_jumptarget2/data/05_release/2022_10_18_JUMP-CP_compound_library.csv
index f427fc9..f4ed023 100644
--- a/3.standardize/standardize_ksiling_jumpmoa_jumptarget2/data/05_release/2022_10_18_JUMP-CP_compound_library.csv
+++ b/3.standardize/standardize_ksiling_jumpmoa_jumptarget2/data/05_release/2022_10_18_JUMP-CP_compound_library.csv
@@ -1,4 +1,4 @@
-jcp2022_id,jcp2020_id,pert_iname,InChIKey,InChIKey_standardized,InChI_standardized,canonical_smiles,jump_cp_control_type,pert_control_iname,Source[1],Source[2],Source[3],Source[4],Selection[1],Selection[2],Selection[3]
+jcp2022_id,jcp2020_id,pert_iname,InChIKey_orig,InChIKey_standardized_orig,InChI_standardized_orig,smiles,jump_cp_control_type,pert_control_iname,Source[1],Source[2],Source[3],Source[4],Selection[1],Selection[2],Selection[3]
```


```sh
python StandardizeMolecule.py \
  run \
  --input="../jump-cellpainting/3.standardize/standardize_ksiling_jumpmoa_jumptarget2/data/05_release/2022_10_18_JUMP-CP_compound_library.csv" \
  --output="/tmp/2022_10_18_JUMP-CP_compound_library_standardized_jump_canonical.csv" \
  --num_cpu=60   --augment --method=jump_alternate_1 --random_seed=42
```